### PR TITLE
Feat: Implement Edit and Delete for Parts in frontend

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -51,8 +51,13 @@ function App() {
     const [showPartUsageModal, setShowPartUsageModal] = useState(false); // New: for Part Usage Form
     const [editingPartUsage, setEditingPartUsage] = useState(null); // New: for Part Usage editing
 
-
     const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000';
+
+    // --- Modal Openers ---
+    const openEditPartModal = (partToEdit) => {
+        setEditingPart(partToEdit);
+        setShowPartModal(true);
+    };
 
     // Effect to fetch data when token or user changes
     const fetchData = useCallback(async () => {
@@ -218,6 +223,31 @@ function App() {
         }
     };
 
+    // Handler for deleting a part
+    const handleDeletePart = async (partId) => {
+        if (!window.confirm("Are you sure you want to delete this part? This action cannot be undone.")) {
+            return;
+        }
+        try {
+            const response = await fetch(`${API_BASE_URL}/parts/${partId}`, {
+                method: 'DELETE',
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                },
+            });
+
+            if (!response.ok && response.status !== 204) { // 204 is also a success for DELETE
+                const errorData = await response.json().catch(() => ({ detail: "Failed to delete part and parse error response." }));
+                throw new Error(errorData.detail || `HTTP error! status: ${response.status}`);
+            }
+
+            await fetchData(); // Refresh data
+        } catch (err) {
+            console.error("Error deleting part:", err);
+            setError(err.message || "Failed to delete part. Please try again."); // Set error for display
+        }
+    };
+
     // Handler for creating a new user
     const handleCreateUser = async (userData) => {
         try {
@@ -260,11 +290,43 @@ function App() {
                 throw new Error(errorData.detail || `HTTP error! status: ${response.status}`);
             }
 
-            await fetchData();
-            setShowPartModal(false);
+            await fetchData(); // Refresh data
+            setShowPartModal(false); // Close modal
         } catch (err) {
             console.error("Error creating part:", err);
-            throw err;
+            throw err; // Re-throw to be caught by PartForm
+        }
+    };
+
+    // Handler for updating an existing part
+    const handleUpdatePart = async (partDataFromForm) => {
+        if (!editingPart || !editingPart.id) {
+            console.error("No part selected for editing or missing ID.");
+            throw new Error("No part selected for editing or missing ID.");
+        }
+        try {
+            // The partDataFromForm contains all form fields, including image_urls
+            // which PartForm prepares (existing + new uploads).
+            const response = await fetch(`${API_BASE_URL}/parts/${editingPart.id}`, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${token}`,
+                },
+                body: JSON.stringify(partDataFromForm), // Send data from the form
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json();
+                throw new Error(errorData.detail || `HTTP error! status: ${response.status}`);
+            }
+
+            setShowPartModal(false);
+            setEditingPart(null);
+            await fetchData(); // Refresh data
+        } catch (err) {
+            console.error("Error updating part:", err);
+            throw err; // Re-throw to be caught by PartForm
         }
     };
 
@@ -642,6 +704,22 @@ function App() {
                         </div>
                     )}
                     <p className="text-sm text-gray-400 mt-3">ID: {part.id}</p>
+                    {user.role === "Oraseas Admin" && (
+                        <div className="mt-4 flex space-x-2">
+                            <button
+                                onClick={() => openEditPartModal(part)}
+                                className="bg-yellow-500 text-white py-1 px-3 rounded-md hover:bg-yellow-600 text-sm"
+                            >
+                                Edit
+                            </button>
+                            <button
+                                onClick={() => handleDeletePart(part.id)}
+                                className="bg-red-500 text-white py-1 px-3 rounded-md hover:bg-red-600 text-sm"
+                            >
+                                Delete
+                            </button>
+                        </div>
+                    )}
                     </div>
                 ))}
                 </div>
@@ -655,8 +733,11 @@ function App() {
             >
                 <PartForm
                     initialData={editingPart || {}}
-                    onSubmit={handleCreatePart}
-                    onClose={() => setShowPartModal(false)}
+                    onSubmit={editingPart ? handleUpdatePart : handleCreatePart}
+                    onClose={() => {
+                        setShowPartModal(false);
+                        setEditingPart(null); // Clear editing state on close
+                    }}
                 />
             </Modal>
 


### PR DESCRIPTION
This commit introduces frontend functionality for editing and deleting parts for users with the 'Oraseas Admin' role.

Changes include:
- Added 'Edit' and 'Delete' buttons to the parts list in App.js.
- Implemented `openEditPartModal` to populate the PartForm with existing data for editing.
- Implemented `handleUpdatePart` in App.js to make a PUT request to the backend API for updating part details, including image URLs.
- The PartForm component now handles image previews and submissions for both create and edit modes.
- Implemented `handleDeletePart` in App.js with a confirmation dialog, making a DELETE request to the backend.
- Ensured the UI refreshes after successful update or delete operations.
- Updated PartForm modal invocation in App.js to correctly pass handlers and data for create vs. edit modes.